### PR TITLE
Provide the `version` input to the `compathelper-action` composite action

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: JuliaRegistries/compathelper-action@main # TODO: delete this line
         with:
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          version: '3'
           cmd: |
             entry_type = CompatHelper.DropEntry()
             CompatHelper.main(; entry_type)


### PR DESCRIPTION
Because we provide the `cmd` input, we MUST also provide the `version` input.